### PR TITLE
Add lead performance analyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # ASD-Leads
-Using sales data and performance metrics to optimize lead dispersal and develop employee analysis and guided coaching prompts
+Using sales data and performance metrics to optimize lead dispersal and develop employee analysis and guided coaching prompts.
+
+## Lead Performance Analyzer
+
+Run the recommendation script to generate lead allocation suggestions:
+
+```bash
+npm run recommend
+```
+
+The results are written to `output/recommendations.json`.

--- a/data/productSplit.json
+++ b/data/productSplit.json
@@ -1,0 +1,12 @@
+{
+  "Chris Knighton": {
+    "shedOnly": {"cnvPct": 0.12, "avgSale": 9000},
+    "steelOnly": {"cnvPct": 0.14, "avgSale": 8500},
+    "total": {"cnvPct": 0.13, "avgSale": 8750}
+  },
+  "Jason Laird": {
+    "shedOnly": {"cnvPct": 0.10, "avgSale": 6500},
+    "steelOnly": {"cnvPct": 0.12, "avgSale": 6300},
+    "total": {"cnvPct": 0.11, "avgSale": 6400}
+  }
+}

--- a/data/weeklyPerformance.json
+++ b/data/weeklyPerformance.json
@@ -1,0 +1,37 @@
+[
+  {
+    "week": "July W1",
+    "data": [
+      { "name": "Chris Knighton", "leads": 23, "contactPct": 0.43, "quotePct": 0.35, "cnvPct": 0.13, "avgSale": 8754.47 },
+      { "name": "Jason Laird", "leads": 20, "contactPct": 0.50, "quotePct": 0.40, "cnvPct": 0.10, "avgSale": 6500.00 }
+    ]
+  },
+  {
+    "week": "July W2",
+    "data": [
+      { "name": "Chris Knighton", "leads": 21, "contactPct": 0.48, "quotePct": 0.36, "cnvPct": 0.14, "avgSale": 8700.00 },
+      { "name": "Jason Laird", "leads": 22, "contactPct": 0.52, "quotePct": 0.42, "cnvPct": 0.11, "avgSale": 6600.00 }
+    ]
+  },
+  {
+    "week": "July W3",
+    "data": [
+      { "name": "Chris Knighton", "leads": 25, "contactPct": 0.45, "quotePct": 0.37, "cnvPct": 0.15, "avgSale": 8800.00 },
+      { "name": "Jason Laird", "leads": 24, "contactPct": 0.55, "quotePct": 0.43, "cnvPct": 0.12, "avgSale": 6550.00 }
+    ]
+  },
+  {
+    "week": "July W4",
+    "data": [
+      { "name": "Chris Knighton", "leads": 24, "contactPct": 0.47, "quotePct": 0.38, "cnvPct": 0.16, "avgSale": 8900.00 },
+      { "name": "Jason Laird", "leads": 23, "contactPct": 0.53, "quotePct": 0.44, "cnvPct": 0.13, "avgSale": 6700.00 }
+    ]
+  },
+  {
+    "week": "July W5",
+    "data": [
+      { "name": "Chris Knighton", "leads": 26, "contactPct": 0.49, "quotePct": 0.40, "cnvPct": 0.17, "avgSale": 8950.00 },
+      { "name": "Jason Laird", "leads": 25, "contactPct": 0.56, "quotePct": 0.45, "cnvPct": 0.14, "avgSale": 6750.00 }
+    ]
+  }
+]

--- a/output/recommendations.json
+++ b/output/recommendations.json
@@ -1,0 +1,24 @@
+[
+  {
+    "name": "Chris Knighton",
+    "neededLeads": 51,
+    "recommendedSplit": {
+      "shed": 24,
+      "steel": 27
+    },
+    "trend": "positive",
+    "cnvAvg": 15,
+    "avgSale": 8820.89
+  },
+  {
+    "name": "Jason Laird",
+    "neededLeads": 106,
+    "recommendedSplit": {
+      "shed": 49,
+      "steel": 57
+    },
+    "trend": "positive",
+    "cnvAvg": 12,
+    "avgSale": 6620
+  }
+]

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "asd-leads",
+  "version": "1.0.0",
+  "description": "Using sales data and performance metrics to optimize lead dispersal and develop employee analysis and guided coaching prompts",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "recommend": "node src/recommendLeads.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/src/recommendLeads.js
+++ b/src/recommendLeads.js
@@ -1,0 +1,82 @@
+const fs = require('fs');
+const path = require('path');
+
+const performancePath = path.join(__dirname, '..', 'data', 'weeklyPerformance.json');
+const splitPath = path.join(__dirname, '..', 'data', 'productSplit.json');
+const outputPath = path.join(__dirname, '..', 'output', 'recommendations.json');
+
+const PLATINUM_BENCHMARK = 100000; // dollars
+const CAPACITY = {
+  'Chris Knighton': 25,
+  'Jason Laird': 20
+};
+
+function loadJSON(p) {
+  return JSON.parse(fs.readFileSync(p, 'utf-8'));
+}
+
+function collectEmployeeData(weeklyData) {
+  const employees = {};
+  for (const week of weeklyData) {
+    for (const rec of week.data) {
+      if (!employees[rec.name]) {
+        employees[rec.name] = [];
+      }
+      employees[rec.name].push({
+        cnvPct: rec.cnvPct,
+        avgSale: rec.avgSale,
+        leads: rec.leads,
+        quotePct: rec.quotePct
+      });
+    }
+  }
+  return employees;
+}
+
+function average(arr, field) {
+  const sum = arr.reduce((acc, item) => acc + item[field], 0);
+  return sum / arr.length;
+}
+
+function analyzeEmployee(name, records, split) {
+  const cnvAvg = average(records, 'cnvPct') * 100; // to percentage
+  const avgSale = average(records, 'avgSale');
+
+  const trend = records[records.length - 1].cnvPct >= records[0].cnvPct ? 'positive' : 'negative';
+
+  const gvpl = (cnvAvg / 100) * avgSale;
+  const capacity = CAPACITY[name] || 0;
+  let neededLeads = Math.ceil(PLATINUM_BENCHMARK / gvpl) - capacity;
+  if (neededLeads < 0) neededLeads = 0;
+
+  const shedGVPL = split.shedOnly.cnvPct * split.shedOnly.avgSale;
+  const steelGVPL = split.steelOnly.cnvPct * split.steelOnly.avgSale;
+  const ratio = steelGVPL === 0 ? 1 : shedGVPL / steelGVPL;
+  const shedLeads = Math.round(neededLeads * ratio / (1 + ratio));
+  const steelLeads = neededLeads - shedLeads;
+
+  return {
+    name,
+    neededLeads,
+    recommendedSplit: { shed: shedLeads, steel: steelLeads },
+    trend,
+    cnvAvg: Number(cnvAvg.toFixed(2)),
+    avgSale: Number(avgSale.toFixed(2))
+  };
+}
+
+function main() {
+  const weeklyData = loadJSON(performancePath);
+  const splitData = loadJSON(splitPath);
+
+  const employees = collectEmployeeData(weeklyData);
+  const results = [];
+  for (const [name, records] of Object.entries(employees)) {
+    const split = splitData[name];
+    if (!split) continue;
+    results.push(analyzeEmployee(name, records, split));
+  }
+  fs.writeFileSync(outputPath, JSON.stringify(results, null, 2));
+}
+
+main();


### PR DESCRIPTION
## Summary
- add weeklyPerformance.json and productSplit.json example datasets
- implement `src/recommendLeads.js` to compute lead needs and allocation
- provide output example in `output/recommendations.json`
- update README with instructions

## Testing
- `npm run recommend`


------
https://chatgpt.com/codex/tasks/task_e_688cfa33facc8332b3fa8f59fcdac0d9